### PR TITLE
Add CI job to run end-to-end tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,33 @@
+# what is defined in this section will be applied at all times
+build --workspace_status_command bin/workspace_status.sh --show_result=0 --show_progress=no
+test --show_result=0 --show_progress=no
+run --show_result=0 --show_progress=no
+
+# what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
+build:rbe --project_id=grakn-dev
+build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
+build:rbe --remote_cache=remotebuildexecution.googleapis.com
+build:rbe --remote_executor=remotebuildexecution.googleapis.com
+build:rbe --bes_backend="buildeventservice.googleapis.com"
+build:rbe --bes_results_url="https://source.cloud.google.com/results/invocations/"
+build:rbe --host_platform=@graknlabs_build_tools//:rbe-ubuntu1604-network-standard
+build:rbe --platforms=@graknlabs_build_tools//:rbe-ubuntu1604-network-standard
+build:rbe --extra_execution_platforms=@graknlabs_build_tools//:rbe-ubuntu1604-network-standard
+build:rbe --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/9.0.0/bazel_0.25.2/java:jdk
+build:rbe --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/9.0.0/bazel_0.25.2/java:jdk
+build:rbe --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:rbe --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:rbe --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/9.0.0/bazel_0.25.2/config:cc-toolchain
+build:rbe --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/9.0.0/bazel_0.25.2/cc:toolchain
+build:rbe --jobs=50
+build:rbe --remote_timeout=3600
+build:rbe --bes_timeout=60s
+build:rbe --tls_enabled=true
+build:rbe --auth_enabled=true
+build:rbe --spawn_strategy=remote
+build:rbe --strategy=Javac=remote
+build:rbe --strategy=Closure=remote
+build:rbe --genrule_strategy=remote
+build:rbe --define=EXECUTOR=remote
+build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:rbe --experimental_strict_action_env=true

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,3 @@
-# what is defined in this section will be applied at all times
-build --workspace_status_command bin/workspace_status.sh --show_result=0 --show_progress=no
-test --show_result=0 --show_progress=no
-run --show_result=0 --show_progress=no
-
-# what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
 build:rbe --project_id=grakn-dev
 build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
 build:rbe --remote_cache=remotebuildexecution.googleapis.com

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,12 @@ commands:
           command: bazel run @graknlabs_build_tools//ci:run-bazel-rbe -- << parameters.command >>
           no_output_timeout: 1h
 
+  run-grakn-server:
+    steps:
+      - run: bazel build @graknlabs_grakn_core//:assemble-linux-targz
+      - run: mkdir dist && tar -xvzf bazel-genfiles/external/graknlabs_grakn_core/grakn-core-all-linux.tar.gz -C ./dist/
+      - run: nohup ./dist/grakn-core-all-linux/grakn server start
+
 jobs:
   build:
     machine: true
@@ -26,3 +32,24 @@ jobs:
       - run-bazel-rbe:
           command: bazel build //...
       - run: bazel run @graknlabs_build_tools//unused_deps -- list
+
+  test-end-to-end:
+    machine: true
+    working_directory: ~/simulation
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run-grakn-server
+      - run-bazel-rbe:
+          command: bazel run //:simulation-binary -- -k world
+      - run-bazel-rbe:
+          command: bazel test //agents/test/... --test_arg=localhost:48555 --cache_test_results=no
+
+workflows:
+  version: 2
+  simulation:
+    jobs:
+      - build
+      - test-end-to-end:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,8 @@ commands:
 
   run-grakn-server:
     steps:
-      - run: bazel build @graknlabs_grakn_core//:assemble-linux-targz
+      - run-bazel-rbe:
+          command: bazel build @graknlabs_grakn_core//:assemble-linux-targz
       - run: mkdir dist && tar -xvzf bazel-genfiles/external/graknlabs_grakn_core/grakn-core-all-linux.tar.gz -C ./dist/
       - run: nohup ./dist/grakn-core-all-linux/grakn server start
 
@@ -40,10 +41,8 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run-grakn-server
-      - run-bazel-rbe:
-          command: bazel run //:simulation-binary -- -k world
-      - run-bazel-rbe:
-          command: bazel test //agents/test/... --test_arg=localhost:48555 --cache_test_results=no
+      - run: bazel run //:simulation -- -k world
+      - run: bazel test //agents/test/... --test_arg=localhost:48555
 
 workflows:
   version: 2

--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
 java_library(
-    name = "simulation",
+    name = "simulation-lib",
     srcs = glob(["*.java"]),
     data = glob([
         "schema/*.gql",
@@ -22,15 +22,15 @@ java_library(
 )
 
 java_binary(
-    name = "simulation-binary",
+    name = "simulation",
     main_class = "grakn.simulation.Simulation",
-    runtime_deps = [":simulation"],
+    runtime_deps = [":simulation-lib"],
 )
 
 java_binary(
-    name = "simulation-binary-debug",
+    name = "simulation-debug",
     main_class = "grakn.simulation.Simulation",
-    runtime_deps = [":simulation"],
+    runtime_deps = [":simulation-lib"],
     jvm_flags = [
         "-Xdebug",
         "-Xrunjdwp:transport=dt_socket,server=y,address=5005",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Build and run Simulation
 ```shell script
-bazel run //:simulation-binary -- -k world
+bazel run //:simulation -- -k world
 ```
 
 ## CLI options


### PR DESCRIPTION
## What is the goal of this PR?

We add CI configuration such that the simulation is run and "end-to-end" tests are run against the resulting knowledge graph.

## What are the changes implemented in this PR?

- Added a new CircleCI job to run the simulation and then run the tests on the resulting data
- Updated the call to tests to include the grakn uri such that when the non-default is needed it is obvious what to change. Also turn off caching, since bazel may cache the test results based on the fact that none of the tests' dependencies have changed, when in fact the code that generates the KB has changed
- Add `.bazelrc`