### PR TITLE
Add currency to annual-wage as an attribute of an implicit relation

### DIFF
--- a/agents/EmploymentAgent.java
+++ b/agents/EmploymentAgent.java
@@ -54,16 +54,30 @@ public class EmploymentAgent extends CityAgent {
 
     private void insertEmployment(String employeeEmail, Long companyNumber){
         GraqlInsert insertEmploymentQuery = Graql.match(
-                Graql.var("city").isa("city").has("location-name", city().name()),
-                Graql.var("p").isa("person").has("email", employeeEmail),
-                Graql.var("company").isa("company").has("company-number", companyNumber)
+                Graql.var("city")
+                        .isa("city")
+                        .has("location-name", city().name()),
+                Graql.var("p")
+                        .isa("person")
+                        .has("email", employeeEmail),
+                Graql.var("company")
+                        .isa("company")
+                        .has("company-number", companyNumber),
+                Graql.var("country")
+                        .isa("country")
+                        .has("currency", Graql.var("currency")),
+                Graql.var("lh")
+                        .isa("location-hierarchy")
+                        .rel(Graql.var("city"))
+                        .rel(Graql.var("country"))
         ).insert(
                 Graql.var("emp").isa("employment")
                         .rel("employment_employee", Graql.var("p"))
                         .rel("employment_employer", Graql.var("company"))
                         .rel("employment_contract", Graql.var("contract"))
                         .has("start-date", employmentDate)
-                        .has("annual-wage", randomAttributeGenerator().boundRandomDouble(MIN_ANNUAL_WAGE, MAX_ANNUAL_WAGE)),
+                        .has("annual-wage", randomAttributeGenerator().boundRandomDouble(MIN_ANNUAL_WAGE, MAX_ANNUAL_WAGE), Graql.var("r")),
+                Graql.var("r").has("currency", Graql.var("currency")), //TODO Should this be inferred rather than inserted?
                 Graql.var("locates").isa("locates")
                         .rel("locates_located", Graql.var("emp"))
                         .rel("locates_location", Graql.var("city")),

--- a/agents/test/QueryCountE2E.java
+++ b/agents/test/QueryCountE2E.java
@@ -61,8 +61,8 @@ public class QueryCountE2E {
                         .rel("employment_contract", Graql.var("contract"))
                         .has("start-date", Graql.var("employment-date"))
                         .has("annual-wage", Graql.var("annual-wage"), Graql.var("r")),
-//                        Test times out when querying for currency too
-//                Graql.var("r").has("currency", Graql.var("currency")), // TODO Should this be inferred rather than inserted?
+//                TODO Test times out when querying for currency https://github.com/graknlabs/simulation/issues/41
+//                Graql.var("r").has("currency", Graql.var("currency")),
                 Graql.var("locates").isa("locates")
                         .rel("locates_located", Graql.var("emp"))
                         .rel("locates_location", Graql.var("city")),

--- a/agents/test/QueryCountE2E.java
+++ b/agents/test/QueryCountE2E.java
@@ -60,7 +60,15 @@ public class QueryCountE2E {
                         .rel("employment_employer", Graql.var("company"))
                         .rel("employment_contract", Graql.var("contract"))
                         .has("start-date", Graql.var("employment-date"))
-                        .has("annual-wage", Graql.var("annual-wage"))
+                        .has("annual-wage", Graql.var("annual-wage"), Graql.var("r")),
+//                        Test times out when querying for currency too
+//                Graql.var("r").has("currency", Graql.var("currency")), // TODO Should this be inferred rather than inserted?
+                Graql.var("locates").isa("locates")
+                        .rel("locates_located", Graql.var("emp"))
+                        .rel("locates_location", Graql.var("city")),
+                Graql.var("contract").isa("employment-contract")
+                        .has("contract-content", Graql.var("contract-content"))
+                        .has("contracted-hours", Graql.var("contracted-hours"))
         ).get().count();
         assertQueryCount(countQuery, 200);
     }


### PR DESCRIPTION
## What is the goal of this PR?

Add currency to annual-wage as an attribute of an implicit relation

## What are the changes implemented in this PR?

This is a simple extension of the query already present in the `EmploymentAgent`. Worth noting that this could be achieved by reasoning too, but we don't have a case when we do insertion onto an implicit relation like this, so better to keep it this way for now. Particularly since querying for `currency` in the query count test causes the test to time out, and therefore we need to benchmark this urgently!

resolves #35 