### PR TITLE
Add content-language to contract-content using a rule

### DIFF
--- a/Simulation.java
+++ b/Simulation.java
@@ -180,7 +180,8 @@ public class Simulation implements AgentContext, AutoCloseable {
                         loadData(session,
                                 files.get("data.yaml"),
                                 files.get("currencies.yaml"),
-                                files.get("country_currencies.yaml"));
+                                files.get("country_currencies.yaml"),
+                                files.get("country_languages.yaml"));
                     }
                 }
 

--- a/agents/test/QueryCountE2E.java
+++ b/agents/test/QueryCountE2E.java
@@ -55,6 +55,7 @@ public class QueryCountE2E {
     @Test
     public void testEmploymentAgentInsertsTheExpectedNumberOfEmployments() {
         GraqlGet.Aggregate countQuery = Graql.match(
+                Graql.var("city").isa("city"),
                 Graql.var("emp").isa("employment")
                         .rel("employment_employee", Graql.var("p"))
                         .rel("employment_employer", Graql.var("company"))
@@ -69,6 +70,7 @@ public class QueryCountE2E {
                 Graql.var("contract").isa("employment-contract")
                         .has("contract-content", Graql.var("contract-content"))
                         .has("contracted-hours", Graql.var("contracted-hours"))
+//                Graql.var("contract-content").has("content-language", Graql.var("lang"))  // TODO causes test to time out https://github.com/graknlabs/simulation/issues/42
         ).get().count();
         assertQueryCount(countQuery, 200);
     }

--- a/data/country_languages.yaml
+++ b/data/country_languages.yaml
@@ -1,0 +1,10 @@
+template: match $country isa country, has location-name <0>; insert $country has language <1>;
+data: |
+  USA,English
+  United Kingdom,English
+  Germany,German
+  Brazil,Portugese
+  South Africa,English
+  South Africa,Afrikaans
+  China,Mandarin
+  Australia,English

--- a/schema/schema-pt2.gql
+++ b/schema/schema-pt2.gql
@@ -10,6 +10,21 @@ occupation sub entity,
 employment-contract sub legal-contract,
     plays employment_contract;
 
+contract-has-language-of-location-is-there-is-only-one-language sub rule,
+when {
+    $emp(employment_contract: $contract) isa employment;
+    $contract isa employment-contract, has contract-content $content;
+    ($emp, $location1) isa locates;
+    $location1 has language $lang1;
+    not {
+        ($emp, $location2) isa locates;
+        $location2 has language $lang2;
+        $lang1 !== $lang2;
+    };
+}, then {
+    $content has content-language $lang1;
+};
+
 contracted-hours-apply-to-employment sub rule,
 when {
     $emp(employment_contract: $c) isa employment;

--- a/schema/schema.gql
+++ b/schema/schema.gql
@@ -44,23 +44,25 @@ relocation-date sub date-of-event;
 gender sub attribute,
     datatype string;
 
-contracted-hours sub attribute,
-    datatype double;
-
-contract-content sub attribute,
-    datatype string;
-
-language sub attribute, 
+language sub attribute,
     datatype string,
-    regex "^(English|French|German|Cantonese|Hindi|Malaysian|Indonesian)$";
+    regex "^(English|German|Portugese|Afrikaans|Mandarin)$";
+
+content-language sub attribute,
+    datatype string;
 
 num-characters sub attribute,
     datatype long;
 
 text-content sub attribute, 
     datatype string,
-    has language,
+    has content-language,
     has num-characters;
+
+contract-content sub text-content;
+
+contracted-hours sub attribute,
+    datatype double;
 
 annual-wage sub attribute,
     datatype double;
@@ -69,7 +71,7 @@ currency-code sub attribute,
     datatype string,
     regex "^(USD|GBP|EUR|BRL|ZAR|RMB|AUD)$";
 
-currency sub attribute, 
+currency sub attribute,
     datatype string,
     regex "^(American Dollar|Great British Pound|Euro|Brazilian Real|South African Rand|Renminbi|Australian Dollar)$",
     has currency-code;
@@ -128,6 +130,7 @@ city sub location,
 
 country sub location,
     has currency,
+    has language,
     plays incorporation_incorporating;
 
 continent sub location,
@@ -147,6 +150,17 @@ when {
     $lh2(location-hierarchy_superior: $b, location-hierarchy_subordinate: $c) isa location-hierarchy;
 }, then {
     (location-hierarchy_superior: $a, location-hierarchy_subordinate: $c) isa location-hierarchy;
+};
+
+# Transitive group membership
+# Here we realise that it's common to say that when something takes place in a location it also takes place in the superior places.
+# This will lead to many rules of this kind. Can this be generified, and should it be?
+locates-transitive-with-location-hierarchy sub rule,
+when {
+    $loc(locates_located: $thing, locates_location: $a) isa locates;
+    $lh2(location-hierarchy_superior: $b, location-hierarchy_subordinate: $a) isa location-hierarchy;
+}, then {
+    (locates_located: $thing, locates_location: $b) isa locates;
 };
 
 # --------------------------------------------------------
@@ -207,17 +221,6 @@ marriage sub relation,
 born-in sub locates,
     relates born-in_place-of-birth as locates_location,
     relates born-in_child as locates_located;
-
-# Transitive group membership
-# Here we realise that it's common to say that when something takes place in a location it also takes place in the superior places.
-# This will lead to many rules of this kind. Can this be generified, and should it be?
-born-in-transitivity sub rule,
-when {
-    $lh1(location-hierarchy_superior: $a, location-hierarchy_subordinate: $b) isa location-hierarchy;
-    $bi(born-in_child: $p, born-in_place-of-birth: $b) isa born-in;
-}, then {
-    (born-in_child: $p, born-in_place-of-birth: $a) isa born-in;
-};
 
 residency sub relation,
     has start-date,


### PR DESCRIPTION
## What is the goal of this PR?

We introduce that an attribute `contract-content` owns an attribute `content-language` where `content-language` is inferred.

## What are the changes implemented in this PR?

- Adds a rule to infer `content-language`
- Add a language for each country with a `.yaml`
- Introduce transitivity for `locates` with `location-hierarchy` transitivity

resolves #37 